### PR TITLE
fix: change `DEFAULT_QUALITY` from 75 to 0.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ const webpBlob = await arrayBufferToWebP(jpgArrayBuffer, { /** options */ })
 
 ## Options
 
-| Name | Description | Default |
-|-|-|-|
-| quality | image quality | 75 |
-| width | image width | Given image width |
+| Name | Description | Default            |
+|-|-|--------------------|
+| quality | image quality | 0.75               |
+| width | image width | Given image width  |
 | height | image height | Given image height |

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ interface Options {
   height?: number
 }
 
-const DEFAULT_QUALITY = 75;
+const DEFAULT_QUALITY = 0.75;
 
 /**
  * When it cause CORS, you may failed to use


### PR DESCRIPTION
api 설명에 `quality`의 범위가 0~1로 명시되어있고, 그 이외의 숫자가 들어오면 webp 변환은 `0.8`이 기본값으로 사용되는데,

`75`사용시 기본값이 적용되는걸 용량으로 확인했습니다.

<img width="512" alt="test" src="https://github.com/juunini/webp-converter-browser/assets/79135734/4965d64a-9a28-4737-9a25-1dc805701586">

### 참고
[MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#parameters)

[Editor Docs](https://github.com/juunini/webp-converter-browser/assets/79135734/e7b7a506-c013-419b-95ac-3061a4b460b6)